### PR TITLE
feat: change document tsx to improve styled components compatibility

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,13 +1,25 @@
-import { Html, Head, Main, NextScript } from 'next/document'
+import Document, { DocumentContext } from 'next/document'
+import { ServerStyleSheet } from 'styled-components'
 
-export default function Document() {
-  return (
-    <Html lang="en">
-      <Head />
-      <body>
-        <Main />
-        <NextScript />
-      </body>
-    </Html>
-  )
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    const sheet = new ServerStyleSheet()
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) =>
+            sheet.collectStyles(<App {...props} />),
+        })
+
+      const initialProps = await Document.getInitialProps(ctx)
+      return {
+        ...initialProps,
+        styles: [initialProps.styles, sheet.getStyleElement()],
+      }
+    } finally {
+      sheet.seal()
+    }
+  }
 }


### PR DESCRIPTION
## description

change document file to improve styled components compatibility, use [this file](https://github.com/vercel/next.js/blob/canary/examples/with-styled-components/pages/_document.tsx) as reference.